### PR TITLE
fix do_transforms

### DIFF
--- a/R/transformations.R
+++ b/R/transformations.R
@@ -415,6 +415,7 @@ selection = c("delete_equal", "clean_special",
       X = main$special_replaced$value
     } else {
       if ("delete_equal" %in% selection) {
+        X = main$equal_deleted$value$Data_del_equal
       } else {
         X = main$with_types$value$Data_with_types
       }
@@ -437,6 +438,7 @@ selection = c("delete_equal", "clean_special",
         X = main$special_replaced$value
       } else {
         if ("delete_equal" %in% selection) {
+          X = main$equal_deleted$value$Data_del_equal
         } else {
           X = main$with_types$value$Data_with_types
         }


### PR DESCRIPTION
Fixing a bug where a df was not assigned to variable X before applying a transformation with a certain combination (i.e. when "clean_special" wasn't chosen but "delete_equal was, the value of X was missing)